### PR TITLE
Added extra check that allows a user to reenter their sign up form if…

### DIFF
--- a/port_inspector/port_inspector_app/forms.py
+++ b/port_inspector/port_inspector_app/forms.py
@@ -14,6 +14,7 @@ class UserRegisterForm(forms.ModelForm):
     class Meta:
         model = User
         fields = [
+            'name',
             'email',
             'password'
         ]
@@ -21,11 +22,15 @@ class UserRegisterForm(forms.ModelForm):
     def clean(self, *args, **kwargs):
         email = self.cleaned_data.get('email')
         password = self.cleaned_data.get('password')
-        email_check = User.objects.filter(email=email)
-        if email_check.exists():
-            raise forms.ValidationError('This Email already exists')
-        if len(password) < 5:
-            raise forms.ValidationError('Your password should have more than 5 characters')
+        if email and password:
+            email_check = User.objects.filter(email=email).first()
+            if email_check:
+                if email_check.is_active:
+                    raise forms.ValidationError('This Email is already registered')
+                else:
+                    email_check.delete()
+            if len(password) < 5:
+                raise forms.ValidationError('Your password should have more than 5 characters')
         return super(UserRegisterForm, self).clean(*args, **kwargs)
 
 

--- a/port_inspector/port_inspector_app/views.py
+++ b/port_inspector/port_inspector_app/views.py
@@ -70,6 +70,7 @@ def signup_view(request):
             user = form.save(commit=False)
             password = form.cleaned_data.get("password")
             user.set_password(password)
+            user.name = form.cleaned_data.get("name")
             user.save()
             new_user = authenticate(email=user.email, password=password)
             if new_user:


### PR DESCRIPTION
… their account is not active (aka not email verified) so that they can still sign up with their email if they accidentally miss the verification button/email. Added name saving into the form as well so that the name box on the website is no longer useless

# Overview

**Type of Change:** Refactor

**Summary:** Fixed user signup form so that the name field is now properly saved into the name category of the database. Noticed an issue where the user could miss the verify email or not click the verify button and be locked out of creating an account under that email. The site now allows writing over inactive emails (emails that are not verified) so that users cannot be locked out of an account for missing the email verification.

## UI/UX Implementation

None

## Model Updates

Name is now properly saved

### Data Models

None

### Object-Oriented Models

User sign up form can now delete a previous entry given the account was not activated

## End-to-End Testing Instructions

Tests cases:
1. Sign up, but instead of clicking verify, go back one page and attempt to sign up with the same email. Ensure this takes you to the verify page again.
2. Click verify and then dont open the email. Attempt to sign up with the same email again and ensure this allows you to verify again.
3. Properly verify this time and click the email verification link. Try to sign up again and ensure that a message appears saying the email is already in use.
4. Sign in to the profile and check the profile tab's name area. Ensure the entered name appears in the right location
5. Extra but unnecessary: Check that the name appears in the admin database view as well and check that the correct fields are active (is_email_verified and is_active)
