### PR TITLE
is_usda tag is now evaluated upon email verification

### DIFF
--- a/port_inspector/port_inspector_app/views.py
+++ b/port_inspector/port_inspector_app/views.py
@@ -62,6 +62,8 @@ def verify_email_confirm(request, uidb64, token):
     if user is not None and account_activation_token.check_token(user, token):
         user.is_email_verified = True
         user.is_active = True
+        if user.email.lower().strip().endswith("@usda.gov"):
+            user.is_usda = True
         user.save()
         messages.success(request, "Your email has been verified.")
         return redirect("/login/")


### PR DESCRIPTION
# Overview

**Type of Change:** Bug Fix

**Summary:** Changed how is_usda tag is assigned so it properly appears on the user's profile

## UI/UX Implementation

None

## Model Updates

None

### Data Models

None

### Object-Oriented Models

When an email is verified, the email's end tag is processed and checked for @usda.gov and properly updates the is_usda tag

## End-to-End Testing Instructions

Attempt to create a new usda user on the website and check the profile tab to verify that the is_usda tag is true for new @usda.gov accounts and false for non @usda.gov accounts.
