### PR TITLE
Added lambda attn to hyperparameter tuning

### DIFF
--- a/src/cam_training_program.py
+++ b/src/cam_training_program.py
@@ -647,6 +647,7 @@ class CAMGuidedTrainingProgram:
         erasing_p = trial.suggest_float('erasing_p', 0.0, 0.8)
         erasing_scale_min = trial.suggest_float('erasing_scale_min', 0.01, 0.1)
         erasing_scale_max = trial.suggest_float('erasing_scale_max', 0.1, 0.4)
+        lambda_attn = trial.suggest_float("lambda_attn", 0.0, 2.0)
 
         if erasing_scale_min >= erasing_scale_max:
             return 0.0  # Invalid trial
@@ -689,7 +690,8 @@ class CAMGuidedTrainingProgram:
                 test_loader=val_loader,
                 view=view,
                 lr=lrate,
-                optimizer_type=optimizer_type
+                optimizer_type=optimizer_type,
+                lambda_attn=lambda_attn
             )
             fold_scores.append(macro_f1)
 


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature

**Summary:** Added lambda attention to the hyperparameter tuning process in the grad cam training program. Tuning this should increase the accuracy because lambda attention directly controls how much weight you give the CAM-guided loss relative to the classification loss (total_loss = pred_loss + self.lambda_attn * attn_loss).



## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

No changes made.

## End-to-End Testing Instructions

Run the cam_training_simulator.py file and select hyperparameter tuning. Once an optimal lambda attention value has been found change the self.lambda_attn variable in the constructor of the training program to the correct value and rerun training.
