### PR TITLE
Added links to columns in the about page

### DIFF
--- a/port_inspector/port_inspector_app/static/port_inspector_app/about_elements.css
+++ b/port_inspector/port_inspector_app/static/port_inspector_app/about_elements.css
@@ -83,6 +83,7 @@ p {
 }
 .text-list-classes {
     display: flex;
+    flex-direction: column;
     font-size: 0.95rem;
     font-family: 'Roboto mono', monospace;
     background-color: whitesmoke;
@@ -92,6 +93,12 @@ p {
     width: 50%;
     box-sizing: border-box;
     align-items: center;
+}
+.text-list-classes a{
+    color: black;
+}
+.text-list-classes a:visited{
+    color: lightblue;
 }
 .paragraph-header {
     font-family: 'Roboto mono', monospace;

--- a/port_inspector/port_inspector_app/templates/about.html
+++ b/port_inspector/port_inspector_app/templates/about.html
@@ -54,14 +54,14 @@
       <p class="text-list-classes">
         {% for class in valid_classes %}
           {% if forloop.counter|divisibleby:2 %}
-            •{{ class.genus }} {{ class.species }}<br>
+            <a href="/static/{{ class.genus }}_{{ class.species}}" target="_blank">•{{ class.genus }} {{ class.species }}</a>
           {% endif %}
         {% endfor %}
       </p>
       <p class="text-list-classes">
         {% for class in valid_classes %}
           {% if not forloop.counter|divisibleby:2 %}
-            •{{ class.genus }} {{ class.species }}<br>
+            <a href="/static/{{ class.genus }}_{{ class.species}}" target="_blank">•{{ class.genus }} {{ class.species }}</a>
           {% endif %}
         {% endfor %}
       </p>

--- a/port_inspector/port_inspector_app/templates/about.html
+++ b/port_inspector/port_inspector_app/templates/about.html
@@ -54,14 +54,14 @@
       <p class="text-list-classes">
         {% for class in valid_classes %}
           {% if forloop.counter|divisibleby:2 %}
-            <a href="/static/{{ class.genus }}_{{ class.species}}" target="_blank">•{{ class.genus }} {{ class.species }}</a>
+            <a href="/static/{{ class.genus }}_{{ class.species}}.pdf" target="_blank">•{{ class.genus }} {{ class.species }}</a>
           {% endif %}
         {% endfor %}
       </p>
       <p class="text-list-classes">
         {% for class in valid_classes %}
           {% if not forloop.counter|divisibleby:2 %}
-            <a href="/static/{{ class.genus }}_{{ class.species}}" target="_blank">•{{ class.genus }} {{ class.species }}</a>
+            <a href="/static/{{ class.genus }}_{{ class.species}}.pdf" target="_blank">•{{ class.genus }} {{ class.species }}</a>
           {% endif %}
         {% endfor %}
       </p>


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature

**Summary:** Added links to the text list of species in the about page

## UI/UX Implementation

New links

## Model Updates

None

### Data Models

None

### Object-Oriented Models

None

## End-to-End Testing Instructions

Run the test server and verify the links appear and work as expected. Should link to "source/static/Genus_species"
